### PR TITLE
ensure this script is a no-op when the ENV vars aren't set

### DIFF
--- a/ssh-env-config.sh
+++ b/ssh-env-config.sh
@@ -14,6 +14,23 @@
 
 set -e
 
+if [ -z "$SSH_CONFIG" ] && \
+  [ -z "$SSH_CONFIG_B64" ] && \
+  [ -z "$SSH_CONFIG_PATH" ] && \
+  [ -z "$SSH_KNOWN_HOSTS" ] && \
+  [ -z "$SSH_KNOWN_HOSTS_B64" ] && \
+  [ -z "$SSH_KNOWN_HOSTS_PATH" ] && \
+  [ -z "$SSH_PRIVATE_RSA_KEY" ] && \
+  [ -z "$SSH_PRIVATE_RSA_KEY_B64" ] && \
+  [ -z "$SSH_PRIVATE_RSA_KEY_PATH" ] && \
+  [ -z "$SSH_PRIVATE_DSA_KEY" ] && \
+  [ -z "$SSH_PRIVATE_DSA_KEY_B64" ] && \
+  [ -z "$SSH_PRIVATE_DSA_KEY_PATH" ] && \
+  [ -z "$SSH_DEBUG" ]; then
+    # none of the ENV vars we care about found, so skip the logic in this script
+    [[ $1 ]] && exec "$@"
+fi
+
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 


### PR DESCRIPTION
Sometimes, configuring ssh via ENV vars is a helpful option.

Other times, users prefer to carefully configure ssh via other means that this script can interfere with. For example, non-root pods on kubernetes often don't have $HOME set, but ssh config files might be mounted into the filesystem manually.

Without $HOME, t he mkdir and chmod at the top of this script try to operate on //.ssh, which usually raises a permissions error.

This adds a short circuit to the script so none of the logic executes if all the environment variables it looks for are unset. The giant new conditional is ugly, but maybe it's worthwhile?