### PR TITLE
Add support for ECDSA and ED25519 keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ A Docker entrypoint wrapper which sets up SSH config files based on the followin
 
 * `SSH_CONFIG` - contents of an SSH config file
 * `SSH_KNOWN_HOSTS` - contents of an SSH known_hosts file
-* `SSH_PRIVATE_RSA_KEY` - contents of an SSH private RSA key
 * `SSH_PRIVATE_DSA_KEY` - contents of an SSH private DSA key
+* `SSH_PRIVATE_ECDSA_KEY` - contents of an SSH private ECDSA key
+* `SSH_PRIVATE_ED25519_KEY` - contents of an SSH private ED25519 key
+* `SSH_PRIVATE_RSA_KEY` - contents of an SSH private RSA key
 * `SSH_DEBUG` - enables SSH debug logging
 
 You can also provide base64 encoded versions by adding `_B64` to the end of the environment variable (e.g. `SSH_PRIVATE_RSA_KEY_B64`, useful for environments that don't support newlines) and `_PATH` for specifying a file to get the contents from (e.g. `SSH_PRIVATE_RSA_KEY_PATH`, useful for secret stores mounted as volumes).

--- a/ssh-env-config.sh
+++ b/ssh-env-config.sh
@@ -5,8 +5,10 @@
 #
 #   SSH_CONFIG - contents of an SSH config file
 #   SSH_KNOWN_HOSTS - contents of a SSH known_hosts file
-#   SSH_PRIVATE_RSA_KEY - contents of a SSH private RSA key
-#   SSH_PRIVATE_DSA_KEY - contents of a SSH private DSA key
+#   SSH_PRIVATE_DSA_KEY - contents of an SSH private DSA key
+#   SSH_PRIVATE_ECDSA_KEY - contents of an SSH private ECDSA key
+#   SSH_PRIVATE_ED25519_KEY - contents of an SSH private ED25519 key
+#   SSH_PRIVATE_RSA_KEY - contents of an SSH private RSA key
 #   SSH_DEBUG - switch to a high debug level 3 for all hosts, to help solve SSH issues
 #
 # The environment variables are unset after the files are created to help
@@ -20,12 +22,18 @@ if [ -z "$SSH_CONFIG" ] && \
   [ -z "$SSH_KNOWN_HOSTS" ] && \
   [ -z "$SSH_KNOWN_HOSTS_B64" ] && \
   [ -z "$SSH_KNOWN_HOSTS_PATH" ] && \
-  [ -z "$SSH_PRIVATE_RSA_KEY" ] && \
-  [ -z "$SSH_PRIVATE_RSA_KEY_B64" ] && \
-  [ -z "$SSH_PRIVATE_RSA_KEY_PATH" ] && \
   [ -z "$SSH_PRIVATE_DSA_KEY" ] && \
   [ -z "$SSH_PRIVATE_DSA_KEY_B64" ] && \
   [ -z "$SSH_PRIVATE_DSA_KEY_PATH" ] && \
+  [ -z "$SSH_PRIVATE_ECDSA_KEY" ] && \
+  [ -z "$SSH_PRIVATE_ECDSA_KEY_B64" ] && \
+  [ -z "$SSH_PRIVATE_ECDSA_KEY_PATH" ] && \
+  [ -z "$SSH_PRIVATE_ED25519_KEY" ] && \
+  [ -z "$SSH_PRIVATE_ED25519_KEY_B64" ] && \
+  [ -z "$SSH_PRIVATE_ED25519_KEY_PATH" ] && \
+  [ -z "$SSH_PRIVATE_RSA_KEY" ] && \
+  [ -z "$SSH_PRIVATE_RSA_KEY_B64" ] && \
+  [ -z "$SSH_PRIVATE_RSA_KEY_PATH" ] && \
   [ -z "$SSH_DEBUG" ]; then
     # none of the ENV vars we care about found, so skip the logic in this script
     [[ $1 ]] && exec "$@"
@@ -79,23 +87,6 @@ decode_base64() {
   chmod 600 ~/.ssh/known_hosts && \
   unset SSH_KNOWN_HOSTS_PATH
 
-## ~/.ssh/id_rsa
-
-[[ ! -z "$SSH_PRIVATE_RSA_KEY" ]] && \
-  echo "$SSH_PRIVATE_RSA_KEY" > ~/.ssh/id_rsa && \
-  chmod 600 ~/.ssh/id_rsa && \
-  unset SSH_PRIVATE_RSA_KEY
-
-[[ ! -z "$SSH_PRIVATE_RSA_KEY_B64" ]] && \
-  decode_base64 "$SSH_PRIVATE_RSA_KEY_B64" > ~/.ssh/id_rsa && \
-  chmod 600 ~/.ssh/id_rsa && \
-  unset SSH_PRIVATE_RSA_KEY_B64
-
-[[ ! -z "$SSH_PRIVATE_RSA_KEY_PATH" && ! -a ~/.ssh/id_rsa ]] && \
-  cp "$SSH_PRIVATE_RSA_KEY_PATH" ~/.ssh/id_rsa && \
-  chmod 600 ~/.ssh/id_rsa && \
-  unset SSH_PRIVATE_RSA_KEY_PATH
-
 ## ~/.ssh/id_dsa
 
 [[ ! -z "$SSH_PRIVATE_DSA_KEY" ]] && \
@@ -112,6 +103,57 @@ decode_base64() {
   cp "$SSH_PRIVATE_DSA_KEY_PATH" ~/.ssh/id_dsa && \
   chmod 600 ~/.ssh/id_dsa && \
   unset SSH_PRIVATE_DSA_KEY_PATH
+
+## ~/.ssh/id_ecdsa
+
+[[ ! -z "$SSH_PRIVATE_ECDSA_KEY" ]] && \
+  echo "$SSH_PRIVATE_ECDSA_KEY" > ~/.ssh/id_ecdsa && \
+  chmod 600 ~/.ssh/id_ecdsa && \
+  unset SSH_PRIVATE_ECDSA_KEY
+
+[[ ! -z "$SSH_PRIVATE_ECDSA_KEY_B64" ]] && \
+  decode_base64 "$SSH_PRIVATE_ECDSA_KEY_B64" > ~/.ssh/id_ecdsa && \
+  chmod 600 ~/.ssh/id_ecdsa && \
+  unset SSH_PRIVATE_ECDSA_KEY_B64
+
+[[ ! -z "$SSH_PRIVATE_ECDSA_KEY_PATH" && ! -a ~/.ssh/id_ecdsa ]] && \
+  cp "$SSH_PRIVATE_ECDSA_KEY_PATH" ~/.ssh/id_ecdsa && \
+  chmod 600 ~/.ssh/id_ecdsa && \
+  unset SSH_PRIVATE_ECDSA_KEY_PATH
+
+## ~/.ssh/id_ed25519
+
+[[ ! -z "$SSH_PRIVATE_ED25519_KEY" ]] && \
+  echo "$SSH_PRIVATE_ED25519_KEY" > ~/.ssh/id_ed25519 && \
+  chmod 600 ~/.ssh/id_ed25519 && \
+  unset SSH_PRIVATE_ED25519_KEY
+
+[[ ! -z "$SSH_PRIVATE_ED25519_KEY_B64" ]] && \
+  decode_base64 "$SSH_PRIVATE_ED25519_KEY_B64" > ~/.ssh/id_ed25519 && \
+  chmod 600 ~/.ssh/id_ed25519 && \
+  unset SSH_PRIVATE_ED25519_KEY_B64
+
+[[ ! -z "$SSH_PRIVATE_ED25519_KEY_PATH" && ! -a ~/.ssh/id_ed25519 ]] && \
+  cp "$SSH_PRIVATE_ED25519_KEY_PATH" ~/.ssh/id_ed25519 && \
+  chmod 600 ~/.ssh/id_ed25519 && \
+  unset SSH_PRIVATE_ED25519_KEY_PATH
+
+## ~/.ssh/id_rsa
+
+[[ ! -z "$SSH_PRIVATE_RSA_KEY" ]] && \
+  echo "$SSH_PRIVATE_RSA_KEY" > ~/.ssh/id_rsa && \
+  chmod 600 ~/.ssh/id_rsa && \
+  unset SSH_PRIVATE_RSA_KEY
+
+[[ ! -z "$SSH_PRIVATE_RSA_KEY_B64" ]] && \
+  decode_base64 "$SSH_PRIVATE_RSA_KEY_B64" > ~/.ssh/id_rsa && \
+  chmod 600 ~/.ssh/id_rsa && \
+  unset SSH_PRIVATE_RSA_KEY_B64
+
+[[ ! -z "$SSH_PRIVATE_RSA_KEY_PATH" && ! -a ~/.ssh/id_rsa ]] && \
+  cp "$SSH_PRIVATE_RSA_KEY_PATH" ~/.ssh/id_rsa && \
+  chmod 600 ~/.ssh/id_rsa && \
+  unset SSH_PRIVATE_RSA_KEY_PATH
 
 ## ssh debug mode
 

--- a/tests.sh
+++ b/tests.sh
@@ -33,7 +33,7 @@ docker build --tag "$test_docker_image_name" .
 
 echo "--- SSH config dir permissions tests"
 
-docker run -it --rm "$test_docker_image_name" bash -c "test -x ~/.ssh && echo '~/.ssh is executable'"
+docker run -it -e SSH_CONFIG="$test_string" --rm "$test_docker_image_name" bash -c "test -x ~/.ssh && echo '~/.ssh is executable'"
 
 echo "--- SSH_CONFIG tests"
 
@@ -47,17 +47,29 @@ docker run --rm -e SSH_KNOWN_HOSTS="$test_string" "$test_docker_image_name" bash
 docker run --rm -e SSH_KNOWN_HOSTS_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/known_hosts | grep $test_string"
 docker run --rm -e SSH_KNOWN_HOSTS_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/known_hosts | grep $test_string"
 
-echo "--- SSH_PRIVATE_RSA_KEY tests"
-
-docker run --rm -e SSH_PRIVATE_RSA_KEY="$test_string" "$test_docker_image_name" bash -c "cat ~/.ssh/id_rsa | grep $test_string"
-docker run --rm -e SSH_PRIVATE_RSA_KEY_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_rsa | grep $test_string"
-docker run --rm -e SSH_PRIVATE_RSA_KEY_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_rsa | grep $test_string"
-
 echo "--- SSH_PRIVATE_DSA_KEY tests"
 
 docker run --rm -e SSH_PRIVATE_DSA_KEY="$test_string" "$test_docker_image_name" bash -c "cat ~/.ssh/id_dsa | grep $test_string"
 docker run --rm -e SSH_PRIVATE_DSA_KEY_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_dsa | grep $test_string"
 docker run --rm -e SSH_PRIVATE_DSA_KEY_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_dsa | grep $test_string"
+
+echo "--- SSH_PRIVATE_ECDSA_KEY tests"
+
+docker run --rm -e SSH_PRIVATE_ECDSA_KEY="$test_string" "$test_docker_image_name" bash -c "cat ~/.ssh/id_ecdsa | grep $test_string"
+docker run --rm -e SSH_PRIVATE_ECDSA_KEY_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_ecdsa | grep $test_string"
+docker run --rm -e SSH_PRIVATE_ECDSA_KEY_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_ecdsa | grep $test_string"
+
+echo "--- SSH_PRIVATE_ED25519_KEY tests"
+
+docker run --rm -e SSH_PRIVATE_ED25519_KEY="$test_string" "$test_docker_image_name" bash -c "cat ~/.ssh/id_ed25519 | grep $test_string"
+docker run --rm -e SSH_PRIVATE_ED25519_KEY_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_ed25519 | grep $test_string"
+docker run --rm -e SSH_PRIVATE_ED25519_KEY_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_ed25519 | grep $test_string"
+
+echo "--- SSH_PRIVATE_RSA_KEY tests"
+
+docker run --rm -e SSH_PRIVATE_RSA_KEY="$test_string" "$test_docker_image_name" bash -c "cat ~/.ssh/id_rsa | grep $test_string"
+docker run --rm -e SSH_PRIVATE_RSA_KEY_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_rsa | grep $test_string"
+docker run --rm -e SSH_PRIVATE_RSA_KEY_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_rsa | grep $test_string"
 
 echo "--- SSH_DEBUG tests"
 


### PR DESCRIPTION
- standard filenames taken from https://github.com/openssh/openssh-portable/blob/385ecb31e147dfea59c1c488a1d2011d3867e60e/pathnames.h#L75
- also fix tests.sh as it has been broken since https://github.com/buildkite/docker-ssh-env-config/pull/3 (the if is before the .ssh dir gets created)

Fixes https://github.com/buildkite/docker-ssh-env-config/issues/4