### PR TITLE
Remove support for DSA keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A Docker entrypoint wrapper which sets up SSH config files based on the followin
 
 * `SSH_CONFIG` - contents of an SSH config file
 * `SSH_KNOWN_HOSTS` - contents of an SSH known_hosts file
-* `SSH_PRIVATE_DSA_KEY` - contents of an SSH private DSA key
 * `SSH_PRIVATE_ECDSA_KEY` - contents of an SSH private ECDSA key
 * `SSH_PRIVATE_ED25519_KEY` - contents of an SSH private ED25519 key
 * `SSH_PRIVATE_RSA_KEY` - contents of an SSH private RSA key

--- a/ssh-env-config.sh
+++ b/ssh-env-config.sh
@@ -22,9 +22,6 @@ if [ -z "$SSH_CONFIG" ] && \
   [ -z "$SSH_KNOWN_HOSTS" ] && \
   [ -z "$SSH_KNOWN_HOSTS_B64" ] && \
   [ -z "$SSH_KNOWN_HOSTS_PATH" ] && \
-  [ -z "$SSH_PRIVATE_DSA_KEY" ] && \
-  [ -z "$SSH_PRIVATE_DSA_KEY_B64" ] && \
-  [ -z "$SSH_PRIVATE_DSA_KEY_PATH" ] && \
   [ -z "$SSH_PRIVATE_ECDSA_KEY" ] && \
   [ -z "$SSH_PRIVATE_ECDSA_KEY_B64" ] && \
   [ -z "$SSH_PRIVATE_ECDSA_KEY_PATH" ] && \
@@ -86,23 +83,6 @@ decode_base64() {
   cp "$SSH_KNOWN_HOSTS_PATH" ~/.ssh/known_hosts && \
   chmod 600 ~/.ssh/known_hosts && \
   unset SSH_KNOWN_HOSTS_PATH
-
-## ~/.ssh/id_dsa
-
-[[ ! -z "$SSH_PRIVATE_DSA_KEY" ]] && \
-  echo "$SSH_PRIVATE_DSA_KEY" > ~/.ssh/id_dsa && \
-  chmod 600 ~/.ssh/id_dsa && \
-  unset SSH_PRIVATE_DSA_KEY
-
-[[ ! -z "$SSH_PRIVATE_DSA_KEY_B64" ]] && \
-  decode_base64 "$SSH_PRIVATE_DSA_KEY_B64" > ~/.ssh/id_dsa && \
-  chmod 600 ~/.ssh/id_dsa && \
-  unset SSH_PRIVATE_DSA_KEY_B64
-
-[[ ! -z "$SSH_PRIVATE_DSA_KEY_PATH" && ! -a ~/.ssh/id_dsa ]] && \
-  cp "$SSH_PRIVATE_DSA_KEY_PATH" ~/.ssh/id_dsa && \
-  chmod 600 ~/.ssh/id_dsa && \
-  unset SSH_PRIVATE_DSA_KEY_PATH
 
 ## ~/.ssh/id_ecdsa
 

--- a/tests.sh
+++ b/tests.sh
@@ -47,12 +47,6 @@ docker run --rm -e SSH_KNOWN_HOSTS="$test_string" "$test_docker_image_name" bash
 docker run --rm -e SSH_KNOWN_HOSTS_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/known_hosts | grep $test_string"
 docker run --rm -e SSH_KNOWN_HOSTS_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/known_hosts | grep $test_string"
 
-echo "--- SSH_PRIVATE_DSA_KEY tests"
-
-docker run --rm -e SSH_PRIVATE_DSA_KEY="$test_string" "$test_docker_image_name" bash -c "cat ~/.ssh/id_dsa | grep $test_string"
-docker run --rm -e SSH_PRIVATE_DSA_KEY_B64="$test_string_base64" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_dsa | grep $test_string"
-docker run --rm -e SSH_PRIVATE_DSA_KEY_PATH="/tests/$test_file" -v "$(pwd):/tests" "$test_docker_image_name" bash -c "cat ~/.ssh/id_dsa | grep $test_string"
-
 echo "--- SSH_PRIVATE_ECDSA_KEY tests"
 
 docker run --rm -e SSH_PRIVATE_ECDSA_KEY="$test_string" "$test_docker_image_name" bash -c "cat ~/.ssh/id_ecdsa | grep $test_string"


### PR DESCRIPTION
- OpenSSH has removed support for DSA keys and they no longer work in the latest versions: https://lwn.net/Articles/958048/